### PR TITLE
Update the documentation and repository links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # [instances.invidio.us](https://instances.invidio.us)
 
-Status page for [Invidious](https://github.com/omarroth/invidious) instances, sourced from [here](https://github.com/omarroth/invidious/wiki/Invidious-Instances).
+Status page for [Invidious](https://github.com/iv-org/invidious) instances, sourced from [here](https://github.com/iv-org/documentation/blob/master/Invidious-Instances.md).
 
 ## Installation
 
 ```bash
-$ git clone https://github.com/omarroth/instances.invidio.us
+$ git clone https://github.com/iv-org/instances.invidio.us
 $ cd instances.invidio.us
 $ shards install
 $ crystal build src/instances.cr --release
@@ -25,7 +25,7 @@ $ ./instances -h
 
 ## Contributing
 
-1. Fork it (<https://github.com/omarroth/instances.invidio.us/fork>)
+1. Fork it (<https://github.com/iv-org/instances.invidio.us/fork>)
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
@@ -33,4 +33,4 @@ $ ./instances -h
 
 ## Contributors
 
-- [Omar Roth](https://github.com/omarroth) - creator and maintainer
+- [Omar Roth](https://github.com/omarroth) - original creator

--- a/src/instances.cr
+++ b/src/instances.cr
@@ -51,7 +51,7 @@ spawn do
       end
     end
 
-    body = HTTP::Client.get(URI.parse("https://raw.githubusercontent.com/wiki/iv-org/invidious/Invidious-Instances.md")).body
+    body = HTTP::Client.get(URI.parse("https://raw.githubusercontent.com/iv-org/documentation/master/Invidious-Instances.md")).body
     headers = HTTP::Headers.new
 
     instances = {} of String => Instance

--- a/src/instances/views/index.ecr
+++ b/src/instances/views/index.ecr
@@ -51,7 +51,7 @@
   <body>
     <div class="header">
       <p>
-        <span>Add your instance <a href="https://github.com/omarroth/invidious/wiki/Invidious-Instances">here</a>.</span>
+        <span>Open an issue or a pull request to add your instance on <a href="https://github.com/iv-org/documentation/">the documentation repository</a>.</span>
         <span class="right"><a href="/instances.json?pretty=1<% if sort_by != "users" %>&sort_by=<%= sort_by %><% end %>">JSON</a></span>
       </p>
     </div>
@@ -89,7 +89,7 @@
 
     <div class="footer">
       <p>
-        Released under the AGPLv3. Source available <a href="https://github.com/omarroth/instances.invidio.us">here</a>.
+        Released under the AGPLv3. Source available <a href="https://github.com/iv-org/instances.invidio.us">here</a>.
         <br>
         This site is built with ❤️ using <a href="https://purecss.io/">Pure v1.0.1</a>.
       </p>


### PR DESCRIPTION
Due to the addition of multiples [Invidious instance violating the AGPL](https://github.com/iv-org/invidious/issues?q=is%3Aissue+label%3A%22agpl+violation%22). The documentation has been moved to its own repository: https://github.com/iv-org/documentation

This PR also update the link to the repository of this project.

Closes: #14 